### PR TITLE
Compile with no_keywords for glib compatibility

### DIFF
--- a/frida-qml.pro
+++ b/frida-qml.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib
-CONFIG += qt plugin qmltypes
+CONFIG += qt no_keywords plugin qmltypes
 QT += quick
 
 QML_IMPORT_NAME = Frida

--- a/src/applicationlistmodel.cpp
+++ b/src/applicationlistmodel.cpp
@@ -70,7 +70,7 @@ void ApplicationListModel::setDevice(Device *device)
         return;
 
     m_device = device;
-    emit deviceChanged(device);
+    Q_EMIT deviceChanged(device);
 
     FridaDevice *handle = nullptr;
     if (device != nullptr) {
@@ -81,11 +81,10 @@ void ApplicationListModel::setDevice(Device *device)
 
     if (!m_applications.isEmpty()) {
         beginRemoveRows(QModelIndex(), 0, m_applications.size() - 1);
-        foreach (Application *application, m_applications)
-            delete application;
+        qDeleteAll(m_applications);
         m_applications.clear();
         endRemoveRows();
-        emit countChanged(0);
+        Q_EMIT countChanged(0);
     }
 }
 
@@ -187,13 +186,13 @@ void ApplicationListModel::onEnumerateReady(FridaDevice *handle, GAsyncResult *r
             g_object_unref(applicationHandle);
         }
 
-        foreach (QString identifier, m_identifiers) {
+        for (const QString &identifier : qAsConst(m_identifiers)) {
             if (!current.contains(identifier)) {
                 removed.insert(identifier);
             }
         }
 
-        foreach (QString identifier, removed) {
+        for (const QString &identifier : qAsConst(removed)) {
             m_identifiers.remove(identifier);
         }
 
@@ -221,7 +220,7 @@ int ApplicationListModel::score(Application *application)
 
 void ApplicationListModel::updateItems(void *handle, QList<Application *> added, QSet<QString> removed)
 {
-    foreach (Application *application, added) {
+    for (Application *application : qAsConst(added)) {
         application->setParent(this);
     }
 
@@ -234,7 +233,7 @@ void ApplicationListModel::updateItems(void *handle, QList<Application *> added,
 
     QModelIndex parentRow;
 
-    foreach (QString identifier, removed) {
+    for (const QString& identifier : qAsConst(removed)) {
         auto size = m_applications.size();
         for (int i = 0; i != size; i++) {
             auto application = m_applications[i];
@@ -248,7 +247,7 @@ void ApplicationListModel::updateItems(void *handle, QList<Application *> added,
         }
     }
 
-    foreach (Application *application, added) {
+    for (Application *application : qAsConst(added)) {
         QString name = application->name();
         auto applicationScore = score(application);
         int index = -1;
@@ -274,22 +273,22 @@ void ApplicationListModel::updateItems(void *handle, QList<Application *> added,
 
     int newCount = m_applications.count();
     if (newCount != previousCount)
-        emit countChanged(newCount);
+        Q_EMIT countChanged(newCount);
 }
 
 void ApplicationListModel::beginLoading()
 {
     m_isLoading = true;
-    emit isLoadingChanged(m_isLoading);
+    Q_EMIT isLoadingChanged(m_isLoading);
 }
 
 void ApplicationListModel::endLoading()
 {
     m_isLoading = false;
-    emit isLoadingChanged(m_isLoading);
+    Q_EMIT isLoadingChanged(m_isLoading);
 }
 
 void ApplicationListModel::onError(QString message)
 {
-    emit error(message);
+    Q_EMIT error(message);
 }

--- a/src/applicationlistmodel.h
+++ b/src/applicationlistmodel.h
@@ -39,7 +39,7 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
-signals:
+Q_SIGNALS:
     void countChanged(int newCount);
     void deviceChanged(Device *newDevice);
     void isLoadingChanged(bool newIsLoading);
@@ -53,7 +53,7 @@ private:
 
     static int score(Application *application);
 
-private slots:
+private Q_SLOTS:
     void updateItems(void *handle, QList<Application *> added, QSet<QString> removed);
     void beginLoading();
     void endLoading();

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -206,7 +206,7 @@ void Device::performInject(int pid, ScriptInstance *wrapper)
         session = new SessionEntry(this, pid);
         m_sessions[pid] = session;
         connect(session, &SessionEntry::detached, [=] () {
-            foreach (ScriptEntry *script, session->scripts())
+            for (ScriptEntry *script : session->scripts())
                 m_scripts.remove(script->wrapper());
             m_sessions.remove(pid);
             m_mainContext->schedule([=] () {
@@ -404,11 +404,11 @@ void SessionEntry::onAttachReady(GAsyncResult *res)
 
         g_signal_connect_swapped(m_handle, "detached", G_CALLBACK(onDetachedWrapper), this);
 
-        foreach (ScriptEntry *script, m_scripts) {
+        for (ScriptEntry *script : qAsConst(m_scripts)) {
             script->updateSessionHandle(m_handle);
         }
     } else {
-        foreach (ScriptEntry *script, m_scripts) {
+        for (ScriptEntry *script : qAsConst(m_scripts)) {
             script->notifySessionError(error);
         }
         g_clear_error(&error);
@@ -445,10 +445,10 @@ void SessionEntry::onDetached(DetachReason reason)
         g_assert_not_reached();
     }
 
-    foreach (ScriptEntry *script, m_scripts)
+    for (ScriptEntry *script : qAsConst(m_scripts))
         script->notifySessionError(message);
 
-    emit detached(reason);
+    Q_EMIT detached(reason);
 }
 
 ScriptEntry::ScriptEntry(SessionEntry *session, ScriptInstance *wrapper, QObject *parent) :
@@ -594,7 +594,7 @@ void ScriptEntry::stop()
     m_status = ScriptInstance::Status::Destroyed;
 
     if (canStopNow)
-        emit stopped();
+        Q_EMIT stopped();
 }
 
 void ScriptEntry::onCreateFromSourceReadyWrapper(GObject *obj, GAsyncResult *res, gpointer data)
@@ -631,7 +631,7 @@ void ScriptEntry::onCreateComplete(FridaScript **handle, GError **error)
         g_clear_object(handle);
         g_clear_error(error);
 
-        emit stopped();
+        Q_EMIT stopped();
         return;
     }
 
@@ -665,7 +665,7 @@ void ScriptEntry::onLoadReady(GAsyncResult *res)
     if (m_status == ScriptInstance::Status::Destroyed) {
         g_clear_error(&error);
 
-        emit stopped();
+        Q_EMIT stopped();
         return;
     }
 

--- a/src/device.h
+++ b/src/device.h
@@ -43,7 +43,7 @@ public:
     Q_INVOKABLE ScriptInstance *inject(Script *script, QString program, SpawnOptions *options = nullptr);
     Q_INVOKABLE ScriptInstance *inject(Script *script, int pid);
 
-signals:
+Q_SIGNALS:
     void idChanged(QString newId);
     void nameChanged(QString newName);
     void typeChanged(Type newType);
@@ -57,7 +57,7 @@ private:
     static void onResumeReadyWrapper(GObject *obj, GAsyncResult *res, gpointer data);
     void onResumeReady(GAsyncResult *res, ScriptInstance *wrapper);
     void performInject(int pid, ScriptInstance *wrapper);
-private slots:
+private Q_SLOTS:
     void tryPerformLoad(ScriptInstance *wrapper);
 private:
     void performLoad(ScriptInstance *wrapper, QString name, Script::Runtime runtime, QByteArray code);
@@ -110,7 +110,7 @@ public:
     void disableDebugger();
     void enableJit();
 
-signals:
+Q_SIGNALS:
     void detached(DetachReason reason);
 
 private:
@@ -144,7 +144,7 @@ public:
     void stop();
     void post(QJsonValue value);
 
-signals:
+Q_SIGNALS:
     void stopped();
 
 private:

--- a/src/devicelistmodel.cpp
+++ b/src/devicelistmodel.cpp
@@ -65,7 +65,7 @@ void DeviceListModel::onDeviceAdded(Device *device)
     beginInsertRows(QModelIndex(), rowIndex, rowIndex);
     m_devices.append(device);
     endInsertRows();
-    emit countChanged(m_devices.count());
+    Q_EMIT countChanged(m_devices.count());
 }
 
 void DeviceListModel::onDeviceRemoved(Device *device)
@@ -74,5 +74,5 @@ void DeviceListModel::onDeviceRemoved(Device *device)
     beginRemoveRows(QModelIndex(), rowIndex, rowIndex);
     m_devices.removeAt(rowIndex);
     endRemoveRows();
-    emit countChanged(m_devices.count());
+    Q_EMIT countChanged(m_devices.count());
 }

--- a/src/devicelistmodel.h
+++ b/src/devicelistmodel.h
@@ -23,10 +23,10 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
-signals:
+Q_SIGNALS:
     void countChanged(int newCount);
 
-private slots:
+private Q_SLOTS:
     void onDeviceAdded(Device *device);
     void onDeviceRemoved(Device *device);
 

--- a/src/frida.cpp
+++ b/src/frida.cpp
@@ -46,8 +46,7 @@ void Frida::dispose()
 Frida::~Frida()
 {
     m_localSystem = nullptr;
-    foreach (Device *device, m_deviceItems)
-        delete device;
+    qDeleteAll(m_deviceItems);
     m_deviceItems.clear();
 
     frida_device_manager_close_sync(m_handle, nullptr, nullptr);
@@ -146,7 +145,7 @@ void Frida::add(Device *device)
 {
     device->setParent(this);
     m_deviceItems.append(device);
-    emit deviceAdded(device);
+    Q_EMIT deviceAdded(device);
 }
 
 void Frida::removeById(QString id)
@@ -155,7 +154,7 @@ void Frida::removeById(QString id)
         auto device = m_deviceItems.at(i);
         if (device->id() == id) {
             m_deviceItems.removeAt(i);
-            emit deviceRemoved(device);
+            Q_EMIT deviceRemoved(device);
             delete device;
             break;
         }

--- a/src/frida.h
+++ b/src/frida.h
@@ -33,7 +33,7 @@ public:
 
     QList<Device *> deviceItems() const { return m_deviceItems; }
 
-signals:
+Q_SIGNALS:
     void localSystemChanged(Device *newLocalSystem);
     void deviceAdded(Device *device);
     void deviceRemoved(Device *device);
@@ -48,7 +48,7 @@ private:
     void onDeviceAdded(FridaDevice *deviceHandle);
     void onDeviceRemoved(FridaDevice *deviceHandle);
 
-private slots:
+private Q_SLOTS:
     void add(Device *device);
     void removeById(QString id);
 

--- a/src/processlistmodel.cpp
+++ b/src/processlistmodel.cpp
@@ -69,7 +69,7 @@ void ProcessListModel::setDevice(Device *device)
         return;
 
     m_device = device;
-    emit deviceChanged(device);
+    Q_EMIT deviceChanged(device);
 
     FridaDevice *handle = nullptr;
     if (device != nullptr) {
@@ -80,11 +80,10 @@ void ProcessListModel::setDevice(Device *device)
 
     if (!m_processes.isEmpty()) {
         beginRemoveRows(QModelIndex(), 0, m_processes.size() - 1);
-        foreach (Process *process, m_processes)
-            delete process;
+        qDeleteAll(m_processes);
         m_processes.clear();
         endRemoveRows();
-        emit countChanged(0);
+        Q_EMIT countChanged(0);
     }
 }
 
@@ -183,13 +182,13 @@ void ProcessListModel::onEnumerateReady(FridaDevice *handle, GAsyncResult *res)
             g_object_unref(processHandle);
         }
 
-        foreach (unsigned int pid, m_pids) {
+        for (unsigned int pid : qAsConst(m_pids)) {
             if (!current.contains(pid)) {
                 removed.insert(pid);
             }
         }
 
-        foreach (unsigned int pid, removed) {
+        for (unsigned int pid : qAsConst(removed)) {
             m_pids.remove(pid);
         }
 
@@ -217,7 +216,7 @@ int ProcessListModel::score(Process *process)
 
 void ProcessListModel::updateItems(void *handle, QList<Process *> added, QSet<unsigned int> removed)
 {
-    foreach (Process *process, added) {
+    for (Process *process : qAsConst(added)) {
         process->setParent(this);
     }
 
@@ -230,7 +229,7 @@ void ProcessListModel::updateItems(void *handle, QList<Process *> added, QSet<un
 
     QModelIndex parentRow;
 
-    foreach (unsigned int pid, removed) {
+    for (unsigned int pid : qAsConst(removed)) {
         auto size = m_processes.size();
         for (int i = 0; i != size; i++) {
             auto process = m_processes[i];
@@ -244,7 +243,7 @@ void ProcessListModel::updateItems(void *handle, QList<Process *> added, QSet<un
         }
     }
 
-    foreach (Process *process, added) {
+    for (Process *process : qAsConst(added)) {
         QString name = process->name();
         auto processScore = score(process);
         int index = -1;
@@ -270,22 +269,22 @@ void ProcessListModel::updateItems(void *handle, QList<Process *> added, QSet<un
 
     int newCount = m_processes.count();
     if (newCount != previousCount)
-        emit countChanged(newCount);
+        Q_EMIT countChanged(newCount);
 }
 
 void ProcessListModel::beginLoading()
 {
     m_isLoading = true;
-    emit isLoadingChanged(m_isLoading);
+    Q_EMIT isLoadingChanged(m_isLoading);
 }
 
 void ProcessListModel::endLoading()
 {
     m_isLoading = false;
-    emit isLoadingChanged(m_isLoading);
+    Q_EMIT isLoadingChanged(m_isLoading);
 }
 
 void ProcessListModel::onError(QString message)
 {
-    emit error(message);
+    Q_EMIT error(message);
 }

--- a/src/processlistmodel.h
+++ b/src/processlistmodel.h
@@ -39,7 +39,7 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
-signals:
+Q_SIGNALS:
     void countChanged(int newCount);
     void deviceChanged(Device *newDevice);
     void isLoadingChanged(bool newIsLoading);
@@ -53,7 +53,7 @@ private:
 
     static int score(Process *process);
 
-private slots:
+private Q_SLOTS:
     void updateItems(void *handle, QList<Process *> added, QSet<unsigned int> removed);
     void beginLoading();
     void endLoading();

--- a/src/script.h
+++ b/src/script.h
@@ -56,7 +56,7 @@ private:
     ScriptInstance *bind(Device *device, int pid);
     void unbind(ScriptInstance *instance);
 
-signals:
+Q_SIGNALS:
     void statusChanged(Status newStatus);
     void urlChanged(QUrl newUrl);
     void nameChanged(QString newName);
@@ -113,7 +113,7 @@ public:
     Q_INVOKABLE void disableDebugger();
     Q_INVOKABLE void enableJit();
 
-private slots:
+private Q_SLOTS:
     void post(QJsonValue value);
     void onStatus(ScriptInstance::Status status);
     void onSpawnComplete(int pid);
@@ -121,7 +121,7 @@ private slots:
     void onError(QString message);
     void onMessage(QJsonObject object, QVariant data);
 
-signals:
+Q_SIGNALS:
     void statusChanged(Status newStatus);
     void pidChanged(int newPid);
     void processStateChanged(ProcessState newState);

--- a/src/spawnoptions.cpp
+++ b/src/spawnoptions.cpp
@@ -36,9 +36,9 @@ void SpawnOptions::setArgv(QVector<QString> argv)
     frida_spawn_options_set_argv(m_handle, strv, argv.size());
     g_strfreev(strv);
 
-    emit argvChanged(argv);
+    Q_EMIT argvChanged(argv);
     if (!hadArgv)
-        emit hasArgvChanged(true);
+        Q_EMIT hasArgvChanged(true);
 }
 
 void SpawnOptions::unsetArgv()
@@ -46,8 +46,8 @@ void SpawnOptions::unsetArgv()
     if (!hasArgv())
         return;
     frida_spawn_options_set_argv(m_handle, nullptr, 0);
-    emit argvChanged(QVector<QString>());
-    emit hasArgvChanged(false);
+    Q_EMIT argvChanged(QVector<QString>());
+    Q_EMIT hasArgvChanged(false);
 }
 
 bool SpawnOptions::hasEnv() const
@@ -70,9 +70,9 @@ void SpawnOptions::setEnv(QVector<QString> env)
     frida_spawn_options_set_env(m_handle, strv, env.size());
     g_strfreev(strv);
 
-    emit envChanged(env);
+    Q_EMIT envChanged(env);
     if (!hadEnv)
-        emit hasEnvChanged(true);
+        Q_EMIT hasEnvChanged(true);
 }
 
 void SpawnOptions::unsetEnv()
@@ -80,8 +80,8 @@ void SpawnOptions::unsetEnv()
     if (!hasEnv())
         return;
     frida_spawn_options_set_env(m_handle, nullptr, 0);
-    emit envChanged(QVector<QString>());
-    emit hasEnvChanged(false);
+    Q_EMIT envChanged(QVector<QString>());
+    Q_EMIT hasEnvChanged(false);
 }
 
 bool SpawnOptions::hasCwd() const
@@ -104,9 +104,9 @@ void SpawnOptions::setCwd(QString cwd)
     std::string cwdStr = cwd.toStdString();
     frida_spawn_options_set_cwd(m_handle, cwdStr.c_str());
 
-    emit cwdChanged(cwd);
+    Q_EMIT cwdChanged(cwd);
     if (!hadCwd)
-        emit hasCwdChanged(true);
+        Q_EMIT hasCwdChanged(true);
 }
 
 void SpawnOptions::unsetCwd()
@@ -114,8 +114,8 @@ void SpawnOptions::unsetCwd()
     if (!hasCwd())
         return;
     frida_spawn_options_set_cwd(m_handle, nullptr);
-    emit cwdChanged("");
-    emit hasCwdChanged(false);
+    Q_EMIT cwdChanged("");
+    Q_EMIT hasCwdChanged(false);
 }
 
 static QVector<QString> parseStrv(gchar **strv, gint length)

--- a/src/spawnoptions.h
+++ b/src/spawnoptions.h
@@ -42,7 +42,7 @@ public:
     void setCwd(QString cwd);
     Q_INVOKABLE void unsetCwd();
 
-signals:
+Q_SIGNALS:
     void hasArgvChanged(bool newHasArgv);
     void argvChanged(QVector<QString> newArgv);
 


### PR DESCRIPTION
This compile switch makes Qt not define the shorter macros like
`signals`, `slots`, etc. One can still rely on the prefixed uppercase
ones, Q_SIGNALS, Q_SLOTS, Q_EMIT, etc.

This is a way to prevent the collision with `_GDBusInterfaceInfo`,
present in `frida-core.h` which uses a `signals` variable which collides
with the macro.

Ported the code to use the uglier but safer macros, except for the
`foreach` loops, which are converted to ranged for loops with `qAsConst`
to prevent possible detaches of shared containers.